### PR TITLE
Changed preserves to artisan goods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ _ReSharper*/
 **/packages/*
 *.nuget.props
 *.nuget.targets
+*.sln
+*.sln

--- a/QualityScrubber/ModConfig.cs
+++ b/QualityScrubber/ModConfig.cs
@@ -3,7 +3,7 @@
 	public class ModConfig
 	{
 		public int Duration { get; set; } = 30;
-		public bool AllowPreserves { get; set; } = true;
+		public bool AllowArtisanGoods { get; set; } = false;
 		public bool AllowHoney { get; set; } = true;
 		public bool TurnWineIntoGenericWine { get; set; } = false;
 		public bool TurnHoneyIntoGenericHoney { get; set; } = false;

--- a/QualityScrubber/QualityScrubberController.cs
+++ b/QualityScrubber/QualityScrubberController.cs
@@ -48,8 +48,11 @@ namespace QualityScrubber
                 return false;
             }
 
-            // Ignore roe/wine/juice/jelly/pickles
-            if (!Config.AllowPreserves && inputObject.preserve.Value != null)
+
+            // Ignore all artisan groups: Aged Roe, Beer, Caviar, Cheese, Cloth,
+            //      Dinosaur Mayonnaise, Duck Mayonnaise, Goat Cheese, Green Tea, Honey, Jelly,
+            //      Juice, Mayonnaise, Mead, Pale Ale, Pickles, Truffle Oil, Void Mayonnaise, Wine
+            if (!Config.AllowArtisanGoods && inputObject.Category == -26)
             {
                 //Monitor.Log("You can't scrub these yet!", LogLevel.Debug);
                 return false;

--- a/StardewValleyMods.sln
+++ b/StardewValleyMods.sln
@@ -11,9 +11,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QualityScrubber", "QualityS
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QualityScrubberAutomate", "QualityScrubberAutomate\QualityScrubberAutomate.csproj", "{48DD64C4-4541-4B6B-83B2-B95DA1EBD1DE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShowBirthdays", "ShowBirthdays\ShowBirthdays.csproj", "{C7343F03-F56C-4920-BD0E-CF29F05025C3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ShowBirthdays", "ShowBirthdays\ShowBirthdays.csproj", "{C7343F03-F56C-4920-BD0E-CF29F05025C3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CraftableIndustrialFurnace", "CraftableIndustrialFurnace\CraftableIndustrialFurnace.csproj", "{3E1855F5-9C58-4E37-8E68-8A2B3CF5704C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CraftableIndustrialFurnace", "CraftableIndustrialFurnace\CraftableIndustrialFurnace.csproj", "{3E1855F5-9C58-4E37-8E68-8A2B3CF5704C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -36,6 +36,7 @@ Global
 		{DA723C26-CEAB-4045-9A21-E8C1FA424CED}.Release|x86.ActiveCfg = Release|x86
 		{DA723C26-CEAB-4045-9A21-E8C1FA424CED}.Release|x86.Build.0 = Release|x86
 		{CF998EA2-EEBF-4AFA-AE8C-46E765AE27B4}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{CF998EA2-EEBF-4AFA-AE8C-46E765AE27B4}.Debug|Any CPU.Build.0 = Debug|x86
 		{CF998EA2-EEBF-4AFA-AE8C-46E765AE27B4}.Debug|x86.ActiveCfg = Debug|x86
 		{CF998EA2-EEBF-4AFA-AE8C-46E765AE27B4}.Debug|x86.Build.0 = Debug|x86
 		{CF998EA2-EEBF-4AFA-AE8C-46E765AE27B4}.Release|Any CPU.ActiveCfg = Release|x86
@@ -47,8 +48,7 @@ Global
 		{48DD64C4-4541-4B6B-83B2-B95DA1EBD1DE}.Release|Any CPU.ActiveCfg = Release|x86
 		{48DD64C4-4541-4B6B-83B2-B95DA1EBD1DE}.Release|x86.ActiveCfg = Release|x86
 		{48DD64C4-4541-4B6B-83B2-B95DA1EBD1DE}.Release|x86.Build.0 = Release|x86
-		{C7343F03-F56C-4920-BD0E-CF29F05025C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C7343F03-F56C-4920-BD0E-CF29F05025C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7343F03-F56C-4920-BD0E-CF29F05025C3}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{C7343F03-F56C-4920-BD0E-CF29F05025C3}.Debug|x86.ActiveCfg = Debug|x86
 		{C7343F03-F56C-4920-BD0E-CF29F05025C3}.Debug|x86.Build.0 = Debug|x86
 		{C7343F03-F56C-4920-BD0E-CF29F05025C3}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
Expanded the 'Allow preserves' option to 'Allow Artisan Goods'.  Controls scrubbing of:  Aged Roe, Beer, Caviar, Cheese, Cloth, Dinosaur Mayonnaise, Duck Mayonnaise, Goat Cheese, Green Tea, Honey, Jelly, Juice, Mayonnaise, Mead, Pale Ale, Pickles, Truffle Oil, Void Mayonnaise, Wine.

This means that the conversion to generic equivalents of Juice, Roe, Wine, and pickles will be bound by this setting overall. Will try to figure out an independent solution to this in the next commit.